### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/diarymuslim/6238e450-0281-4a3f-9176-ce5f0577c8ff/4735c7f3-b4ae-4cf6-9e92-318ecd35c3e3/_apis/work/boardbadge/a76df18f-ebc0-4b28-8cc0-ab1310f889b9)](https://dev.azure.com/diarymuslim/6238e450-0281-4a3f-9176-ce5f0577c8ff/_boards/board/t/4735c7f3-b4ae-4cf6-9e92-318ecd35c3e3/Microsoft.RequirementCategory)
 # diary-muslim
 landing page diary muslim update readme


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#128](https://dev.azure.com/diarymuslim/6238e450-0281-4a3f-9176-ce5f0577c8ff/_workitems/edit/128). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.